### PR TITLE
chore: move org

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## install
 
 ```sh
-npm install @liftedinit/manifestjs
+npm install @manifest-network/manifestjs
 ```
 
 ## Table of contents
@@ -36,7 +36,7 @@ npm install @liftedinit/manifestjs
 ### RPC Clients
 
 ```js
-import { manifest } from "@liftedinit/manifestjs";
+import { manifest } from "@manifest-network/manifestjs";
 
 const { createRPCQueryClient } = manifest.ClientFactory;
 const client = await createRPCQueryClient({ rpcEndpoint: RPC_ENDPOINT });
@@ -55,7 +55,7 @@ const balances = await client.manifest.exchange.v1beta1.exchangeBalances();
 Import the `manifest` object from `manifestjs`.
 
 ```js
-import { manifest } from "@liftedinit/manifestjs";
+import { manifest } from "@manifest-network/manifestjs";
 
 const { payout } = manifest.module.v1.MessageComposer.withTypeUrl;
 ```
@@ -63,7 +63,7 @@ const { payout } = manifest.module.v1.MessageComposer.withTypeUrl;
 #### TokenFactory Messages
 
 ```js
-import { osmosis } from "@liftedinit/manifestjs";
+import { osmosis } from "@manifest-network/manifestjs";
 
 const { createDenom } = osmosis.tokenfactory.v1.MessageComposer.withTypeUrl;
 ```
@@ -71,7 +71,7 @@ const { createDenom } = osmosis.tokenfactory.v1.MessageComposer.withTypeUrl;
 #### IBC Messages
 
 ```js
-import { ibc } from "@liftedinit/manifestjs";
+import { ibc } from "@manifest-network/manifestjs";
 
 const { transfer } = ibc.applications.transfer.v1.MessageComposer.withTypeUrl;
 ```
@@ -79,7 +79,7 @@ const { transfer } = ibc.applications.transfer.v1.MessageComposer.withTypeUrl;
 #### Cosmos Messages
 
 ```js
-import { cosmos } from "@liftedinit/manifestjs";
+import { cosmos } from "@manifest-network/manifestjs";
 
 const {
   fundCommunityPool,
@@ -116,7 +116,7 @@ Here are the docs on [creating signers](https://github.com/cosmology-tech/cosmos
 Use `getSigningmanifestClient` to get your `SigningStargateClient`, with the proto/amino messages full-loaded. No need to manually add amino types, just require and initialize the client:
 
 ```js
-import { getSigningStargateClient } from "@liftedinit/manifestjs";
+import { getSigningStargateClient } from "@manifest-network/manifestjs";
 
 const stargateClient = await getSigningStargateClient({
   rpcEndpoint,

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@liftedinit/manifestjs",
-  "version": "v2.0.0",
+  "name": "@manifest-network/manifestjs",
+  "version": "v2.1.0",
   "description": "Javascript library for interacting with Manifest",
-  "author": "The Lifted Initiative <info@liftedinit.org>",
-  "homepage": "https://github.com/liftedinit/manifestjs#readme",
+  "author": "Manifest Network <hello@manifest.network>",
+  "homepage": "https://github.com/manifest-network/manifestjs#readme",
   "license": "SEE LICENSE IN LICENSE",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -39,11 +39,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/liftedinit/manifestjs"
+    "url": "https://github.com/manifest-network/manifestjs"
   },
   "keywords": [],
   "bugs": {
-    "url": "https://github.com/liftedinit/manifestjs/issues"
+    "url": "https://github.com/manifest-network/manifestjs/issues"
   },
   "devDependencies": {
     "@cosmology/telescope": "^1.10.6",
@@ -71,7 +71,7 @@
     "@cosmjs/amino": "^0.32.4",
     "@cosmjs/encoding": "^0.32.4",
     "@cosmjs/proto-signing": "^0.32.4",
-    "@cosmjs/stargate": "npm:@liftedinit/stargate@0.32.4-ll.3",
+    "@cosmjs/stargate": "npm:@manifest-network/stargate@0.32.4-ll.3",
     "@cosmjs/tendermint-rpc": "^0.32.4",
     "@cosmology/lcd": "^0.14.0"
   }

--- a/starship/configs/config.group.local.yaml
+++ b/starship/configs/config.group.local.yaml
@@ -4,7 +4,7 @@ version: v1.3.0
 chains:
   - id: manifest-ledger-beta
     name: custom
-    image: ghcr.io/liftedinit/manifest-ledger:v1.0.0
+    image: ghcr.io/manifest-network/manifest-ledger:1.0.8
     home: /root/.manifest
     binary: manifestd
     prefix: manifest
@@ -12,7 +12,7 @@ chains:
     coins: 10000000000000umfx
     hdPath: m/44'/118'/0'/0/0
     coinType: 118
-    repo: https://github.com/liftedinit/manifest-ledger
+    repo: https://github.com/manifest-network/manifest-ledger
     numValidators: 1
     env:
       # The POA Admin is a group address

--- a/starship/docker/Dockerfile
+++ b/starship/docker/Dockerfile
@@ -2,7 +2,7 @@
 # ARG VERSION
 # FROM ${BASE_IMAGE}:${VERSION} AS source
 
-FROM ghcr.io/liftedinit/manifest-ledger:v1.0.0 as source
+FROM ghcr.io/manifest-network/manifest-ledger:1.0.8 as source
 
 FROM alpine:3.16
 

--- a/starship/docker/Makefile
+++ b/starship/docker/Makefile
@@ -4,4 +4,4 @@ setup:
 
 .PHONY: build
 build:
-	docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/liftedinit/manifest-ledger:v1.0.0 .
+	docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/manifest-network/manifest-ledger:1.0.8 .

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,9 +1185,9 @@
     ws "^7"
     xstream "^11.14.0"
 
-"@cosmjs/stargate@npm:@liftedinit/stargate@0.32.4-ll.3":
+"@cosmjs/stargate@npm:@manifest-network/stargate@0.32.4-ll.3":
   version "0.32.4-ll.3"
-  resolved "https://registry.yarnpkg.com/@liftedinit/stargate/-/stargate-0.32.4-ll.3.tgz#9e280aedc3a14561945276bb9fd63227719d501f"
+  resolved "https://registry.yarnpkg.com/@manifest-network/stargate/-/stargate-0.32.4-ll.3.tgz#9e280aedc3a14561945276bb9fd63227719d501f"
   integrity sha512-HhRI9/43EV9jef1gnsGBPrlqJHZwy4MlX0e3VOaaAiYTB9i/0YdMiKoKUoHtMMritWD9ZeiqMtQRyzV3jJKzhg==
   dependencies:
     "@confio/ics23" "^0.6.8"


### PR DESCRIPTION
This pull request updates the project to reflect a rebranding from "Lifted Initiative" to "Manifest Network." The changes update package names, author and repository information, Docker images, and documentation to use the new Manifest Network naming and URLs.

**Rebranding and package updates:**

* Renamed the npm package from `@liftedinit/manifestjs` to `@manifest-network/manifestjs`, updated the version to `v2.1.0`, and changed author, homepage, repository, and bug URLs in `package.json` to reference Manifest Network. Also updated the Stargate dependency to use the new namespace. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R6) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L42-R46) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L74-R74)

**Documentation updates:**

* Updated all import statements and usage examples in `README.md` to reference `@manifest-network/manifestjs` instead of `@liftedinit/manifestjs`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R82) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119-R119)

**Docker and deployment configuration:**

* Changed Docker image references and tags in `starship/docker/Dockerfile`, `starship/docker/Makefile`, and `starship/configs/config.group.local.yaml` to use `manifest-network` images and repositories instead of `liftedinit`. [[1]](diffhunk://#diff-d8b2896f52efb5c624d72b60d8654d78686bfc6513a9b4f124459519f35d3d7fL5-R5) [[2]](diffhunk://#diff-2e4882e23f689137a9a6bec24a9a9dc1acdcced47debc6e6b778df3e8c17867dL7-R7) [[3]](diffhunk://#diff-54295465531241e18dcecd967b34ce9849d9cadd2a6958d3c3839311078a3842L7-R15)